### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2012 YANDEX LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- Adds a top-level `LICENSE` file with the MIT License text, copyright `(c) 2012 YANDEX LLC`.
- Resolves the lack of explicit licensing called out in #880.
- License text matches the one used by other Yandex/BEM-family projects (e.g. [testplane](https://github.com/gemini-testing/testplane/blob/master/LICENSE)) for ecosystem consistency.

Closes #880.

## Test plan
- [x] `LICENSE` file present at repo root
- [x] Contents are unmodified MIT text + correct copyright line
- [ ] Reviewer confirms MIT is the desired license (CC-BY 4.0 was suggested in the issue but MIT was chosen for consistency with the rest of the BEM ecosystem)

https://claude.ai/code/session_013W9CowPMocpyGFzgsNobTM

---
_Generated by [Claude Code](https://claude.ai/code/session_013W9CowPMocpyGFzgsNobTM)_