### PR TITLE
docs(history): обновить ссылки на видео по BEMHTML (закрывает bem.info#371)

### DIFF
--- a/method/history/history.en.md
+++ b/method/history/history.en.md
@@ -820,6 +820,13 @@ After experimenting with template engines, we developed [BEMHTML](https://en.bem
 2. Redefine them on [redefinition levels](../key-concepts/key-concepts.en.md#redefinition-level).
 3. Use these templates both on the server and in the browser, because the templates are compiled into simple and fast JavaScript.
 
+Videos about BEMHTML (in Russian):
+
+* [bemhtml — BEM js template engine](https://vimeo.com/29159832)
+* [BEMHTML. Not yet another template engine (Moscow)](https://vimeo.com/30814503)
+* [BEMHTML. Not yet another template engine (Saint Petersburg)](https://vimeo.com/30786491)
+* [Template engine working with multiple levels of redefinition](https://vimeo.com/42632215)
+
 ## Summary
 
 Before BEM appeared in its current form, it had to go through a long period of tests and experiments.

--- a/method/history/history.ru.md
+++ b/method/history/history.ru.md
@@ -826,11 +826,10 @@ auto/
 
 Видео по BEMHTML:
 
-* [bemhtml — bem js-шаблонизатор](https://ru.bem.info/forum/-78/)
-* [xjst — низкоуровневый js-шаблонизатор](https://ru.bem.info/forum/-79/)
-* [BEMHTML. Not yet another шаблонизатор](https://ru.bem.info/forum/-103/)
-* [BEMHTML. Not yet another шаблонизатор](https://ru.bem.info/forum/-108/)
-* [Шаблонизатор, работающий с несколькими уровнями](https://ru.bem.info/forum/-145/)
+* [bemhtml — bem js-шаблонизатор](https://vimeo.com/29159832)
+* [BEMHTML. Not yet another шаблонизатор (Москва)](https://vimeo.com/30814503)
+* [BEMHTML. Not yet another шаблонизатор (Санкт-Петербург)](https://vimeo.com/30786491)
+* [Шаблонизатор, работающий с несколькими уровнями](https://vimeo.com/42632215)
 
 ## Резюме
 


### PR DESCRIPTION
## Что и зачем

Чиним [bem-site/bem.info#371](https://github.com/bem-site/bem.info/issues/371): на странице **«История создания»** все ссылки в блоке *«Видео по BEMHTML»* ведут на закрытую с 2014 года публичную платформу `video.yandex.ru` через посреднические страницы `ru.bem.info/forum/-78/`, `-103/`, `-108/`, `-145/`. Видео не открываются — 404 / «не поддерживает плеер» / нет соединения.

Доклады в своё время были перезалиты на Vimeo (профиль [Varvara Stepanova](https://vimeo.com/user7969200), канал [BEM](https://vimeo.com/channels/bem)). Подменяю ссылки на актуальные Vimeo-URL.

## Соответствие старых и новых URL

| было | стало | заголовок |
|---|---|---|
| `ru.bem.info/forum/-78/` | https://vimeo.com/29159832 | bemhtml — bem js-шаблонизатор |
| `ru.bem.info/forum/-79/` | — *(удалено)* | xjst — низкоуровневый js-шаблонизатор |
| `ru.bem.info/forum/-103/` | https://vimeo.com/30814503 | BEMHTML. Not yet another шаблонизатор (Москва, YaC) |
| `ru.bem.info/forum/-108/` | https://vimeo.com/30786491 | BEMHTML. Not yet another шаблонизатор (Санкт-Петербург) |
| `ru.bem.info/forum/-145/` | https://vimeo.com/42632215 | Шаблонизатор, работающий с несколькими уровнями |

Видео `xjst — низкоуровневый js-шаблонизатор` на Vimeo не публиковалось (проверил оба профиля и поиск); строку убрал, чтобы не оставлять заведомо битую ссылку.

Двум одинаково озаглавленным «BEMHTML. Not yet another шаблонизатор» добавил уточнения «(Москва)» / «(Санкт-Петербург)» — это две разные записи доклада.

## history.en.md

В английской версии раздел `### BEMHTML template engine` раньше не содержал списка видео вообще. Добавил аналогичный блок с пометкой *(in Russian)* и переведёнными заголовками — английских записей этих докладов не существует, но как минимум англоязычные читатели увидят, что записи есть.